### PR TITLE
Add missing core-menu dep to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#master",
     "core-icon-button": "Polymer/core-icon-button#master",
+    "core-menu": "Polymer/core-menu#master",
     "core-overlay": "Polymer/core-overlay#master"
   }
 }


### PR DESCRIPTION
It looks like [it's being used now](https://github.com/robdodson/core-menu-button/blob/master/core-menu-button.html#L33) but just missing from bower.json
