### PR TITLE
gray demo background to surface any overlay painting problems

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -16,6 +16,7 @@ license that can be found in the LICENSE file.
     body {
 			margin: 0;
 			font-family: sans-serif;
+			background-color: #d3d3d3;
     }
 
     core-toolbar {


### PR DESCRIPTION
There is a long standing bug with both Firefox and Safari where the overlay is missing the background.  Similar to a fixed problem with the paper-menu-button:

https://github.com/Polymer/paper-menu-button/issues/4

Changing the body to gray on demo will surface this kind of problem earlier. 
